### PR TITLE
🔀 Correct documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ yarn global add gluon-build
 
 ## Documentation
 
-Documentation is available on [docs.gluon.dev](https://docs.gluon.dev) or in the docs folder of this repository.
+Documentation is available on [docs.gluon.dev](https://docs.gluon.dev) or in the docs branch of this repository.
 
 ## Licencing notes
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ yarn global add gluon-build
 
 ## Documentation
 
-Documentation is available on [docs.gluon.dev](https://docs.gluon.dev) or in the docs branch of this repository.
+Documentation is available on [docs.gluon.dev](https://docs.gluon.dev) or in the docs folder of this repository.
 
 ## Licencing notes
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ yarn global add gluon-build
 
 ## Documentation
 
-Documentation is available on [Github pages](https://lepton-browser.github.io/build/) or in the docs folder of this repository.
+Documentation is available on [docs.gluon.dev](https://docs.gluon.dev) or in the docs folder of this repository.
 
 ## Licencing notes
 


### PR DESCRIPTION
Changed the readme to show the working page `(docs.gluon.dev)` and the docs branch.