### PR TITLE
🩹Automatically bootstrap

### DIFF
--- a/template/configs/common/mozconfig
+++ b/template/configs/common/mozconfig
@@ -16,3 +16,6 @@ export MOZ_STUB_INSTALLER=1
 export MOZ_INCLUDE_SOURCE_INFO=1
 export MOZ_SOURCE_REPO=https://github.com/dothq/browser-desktop
 export MOZ_SOURCE_CHANGESET=${changeset}
+
+# Bootstrap
+ac_add_options --enable-bootstrap


### PR DESCRIPTION
This will make ``gluon build`` automatically run bootstrapping to find missing deps.

This at least allowed a build to run on Windows.

Thanks to *🐈ねこーぷの妖精🐾#8892* for telling me this via the Fushra Discord.