### PR TITLE
✨Add a Firefox update command

### DIFF
--- a/src/cmds.ts
+++ b/src/cmds.ts
@@ -70,6 +70,14 @@ export const commands: Cmd[] = [
       (await import('./commands/download')).download,
   },
   {
+    cmd: 'update',
+    aliases: ['update-ff'],
+    description: 'Update Firefox to latest version.',
+    requestController: async () =>
+      (await import('./commands/update')).update,
+    disableMiddleware: true,
+  },
+  {
     cmd: 'execute',
     description: 'Execute a command inside the engine directory.',
     requestController: async () => (await import('./commands/execute')).execute,

--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -6,18 +6,8 @@ import { bin_name, config } from '..'
 import { log } from '../log'
 
 import {
-  setupFirefoxSource,
-  shouldSetupFirefoxSource,
+  downloadInternals
 } from './download/firefox'
-import {
-  addAddonsToMozBuild,
-  downloadAddon,
-  generateAddonMozBuild,
-  getAddons,
-  initializeAddon,
-  resolveAddonDownloadUrl,
-  unpackAddon,
-} from './download/addon'
 
 export const download = async (): Promise<void> => {
   const version = config.version.version
@@ -30,20 +20,7 @@ export const download = async (): Promise<void> => {
     process.exit(1)
   }
 
-  if (shouldSetupFirefoxSource()) {
-    await setupFirefoxSource(version)
-  }
-
-  for (const addon of getAddons()) {
-    const downloadUrl = await resolveAddonDownloadUrl(addon)
-    const downloadedXPI = await downloadAddon(downloadUrl, addon)
-
-    await unpackAddon(downloadedXPI, addon)
-    await generateAddonMozBuild(addon)
-    await initializeAddon(addon)
-  }
-
-  await addAddonsToMozBuild(getAddons())
+  await downloadInternals(version)
 
   log.success(
     `You should be ready to make changes to ${config.name}.`,

--- a/src/commands/download/firefox.ts
+++ b/src/commands/download/firefox.ts
@@ -1,5 +1,5 @@
 import execa from 'execa'
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { bin_name } from '../..'
 import { BASH_PATH, ENGINE_DIR, MELON_TMP_DIR } from '../../constants'

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -6,56 +6,14 @@ import { bin_name, config } from '..'
 import { log } from '../log'
 
 import {
-  setupFirefoxSource,
-  shouldSetupFirefoxSource,
+  downloadInternals
 } from './download/firefox'
-import {
-  addAddonsToMozBuild,
-  downloadAddon,
-  generateAddonMozBuild,
-  getAddons,
-  initializeAddon,
-  resolveAddonDownloadUrl,
-  unpackAddon,
-} from './download/addon'
 import { getLatestFF } from '../utils'
-import { rmSync } from 'node:fs'
-import { ENGINE_DIR } from '../constants'
 
 export const update = async (): Promise<void> => {
   const version = await getLatestFF(config.version.product)
 
-  // If gFFVersion isn't specified, provide legible error
-  if (!version) {
-    log.error(
-      'You have not specified a version of firefox in your config file. This is required to build a firefox fork.'
-    )
-    process.exit(1)
-  }
-
-  if (!shouldSetupFirefoxSource()) {
-    log.info('Remove ' + ENGINE_DIR)
-    rmSync(ENGINE_DIR, {
-      recursive: true,
-      force: true
-    })
-    log.info('Download Firefox ' + version)
-    await setupFirefoxSource(version)
-  } else {
-    log.error(`Firefox is missing, run |${bin_name} download| instead.`)
-    process.exit(1)
-  }
-
-  for (const addon of getAddons()) {
-    const downloadUrl = await resolveAddonDownloadUrl(addon)
-    const downloadedXPI = await downloadAddon(downloadUrl, addon)
-
-    await unpackAddon(downloadedXPI, addon)
-    await generateAddonMozBuild(addon)
-    await initializeAddon(addon)
-  }
-
-  await addAddonsToMozBuild(getAddons())
+  await downloadInternals(version)
 
   log.success(
     `Firefox has sucessfully been updated to ${version}.`,

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { bin_name, config } from '..'
+import { log } from '../log'
+
+import {
+  setupFirefoxSource,
+  shouldSetupFirefoxSource,
+} from './download/firefox'
+import {
+  addAddonsToMozBuild,
+  downloadAddon,
+  generateAddonMozBuild,
+  getAddons,
+  initializeAddon,
+  resolveAddonDownloadUrl,
+  unpackAddon,
+} from './download/addon'
+import { getLatestFF } from '../utils'
+import { rmSync } from 'node:fs'
+import { ENGINE_DIR } from '../constants'
+
+export const update = async (): Promise<void> => {
+  const version = await getLatestFF(config.version.product)
+
+  // If gFFVersion isn't specified, provide legible error
+  if (!version) {
+    log.error(
+      'You have not specified a version of firefox in your config file. This is required to build a firefox fork'
+    )
+    process.exit(1)
+  }
+
+  if (!shouldSetupFirefoxSource()) {
+    log.info('Remove ' + ENGINE_DIR)
+    rmSync(ENGINE_DIR, {
+      recursive: true,
+      force: true
+    })
+    log.info('Download Firefox ' + version)
+    await setupFirefoxSource(version)
+  }
+
+  for (const addon of getAddons()) {
+    const downloadUrl = await resolveAddonDownloadUrl(addon)
+    const downloadedXPI = await downloadAddon(downloadUrl, addon)
+
+    await unpackAddon(downloadedXPI, addon)
+    await generateAddonMozBuild(addon)
+    await initializeAddon(addon)
+  }
+
+  await addAddonsToMozBuild(getAddons())
+
+  log.success(
+    `Firefox has sucessfully been updated to ${version}.`,
+    `You should be ready to make changes to ${config.name}.`,
+    '',
+    `You should import the patches next, run |${bin_name} import|.`,
+    `To begin building ${config.name}, run |${bin_name} build|.`
+  )
+  console.log()
+}

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -28,7 +28,7 @@ export const update = async (): Promise<void> => {
   // If gFFVersion isn't specified, provide legible error
   if (!version) {
     log.error(
-      'You have not specified a version of firefox in your config file. This is required to build a firefox fork'
+      'You have not specified a version of firefox in your config file. This is required to build a firefox fork.'
     )
     process.exit(1)
   }
@@ -41,6 +41,9 @@ export const update = async (): Promise<void> => {
     })
     log.info('Download Firefox ' + version)
     await setupFirefoxSource(version)
+  } else {
+    log.error('Firefox is missing, run |gluon download| instead.')
+    process.exit(1)
   }
 
   for (const addon of getAddons()) {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -42,7 +42,7 @@ export const update = async (): Promise<void> => {
     log.info('Download Firefox ' + version)
     await setupFirefoxSource(version)
   } else {
-    log.error('Firefox is missing, run |gluon download| instead.')
+    log.error(`Firefox is missing, run |${bin_name} download| instead.`)
     process.exit(1)
   }
 

--- a/src/middleware/update-check.ts
+++ b/src/middleware/update-check.ts
@@ -1,7 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import { config } from '..'
+import { bin_name, config } from '..'
 import { log } from '../log'
 import { getLatestFF } from '../utils'
 
@@ -13,7 +13,7 @@ export const updateCheck = async (): Promise<void> => {
 
     if (firefoxVersion && version !== firefoxVersion)
       log.warning(
-        `Latest version of Firefox (${version}) does not match frozen version (${firefoxVersion}). Update Firefox with the command |gluon update|.`
+        `Latest version of Firefox (${version}) does not match frozen version (${firefoxVersion}). Update Firefox with the command |${bin_name} update|.`
       )
   } catch (error) {
     log.warning(`Failed to check for updates.`)

--- a/src/middleware/update-check.ts
+++ b/src/middleware/update-check.ts
@@ -13,7 +13,7 @@ export const updateCheck = async (): Promise<void> => {
 
     if (firefoxVersion && version !== firefoxVersion)
       log.warning(
-        `Latest version of Firefox (${version}) does not match frozen version (${firefoxVersion}).`
+        `Latest version of Firefox (${version}) does not match frozen version (${firefoxVersion}). Update Firefox with the command |gluon update|.`
       )
   } catch (error) {
     log.warning(`Failed to check for updates.`)


### PR DESCRIPTION
Adds a command to update Firefox to the latest firefox build of your vendor. I haven't had time to test it but jest runs all tests fine and I think this would be (mostly) fine to add.

I'm not sure about adding version args to the update command so you can choose what version to update to, but if you know how feel free to add a review or explain.