### PR TITLE
🔗Make gluon/ a part of the .gitignore

### DIFF
--- a/src/commands/setup-project.ts
+++ b/src/commands/setup-project.ts
@@ -158,7 +158,7 @@ export async function setupProject(): Promise<void> {
     }
 
     gitignoreContents +=
-      '\n.dotbuild/\n.gluon\nengine/\nfirefox-*/\nnode_modules/\n'
+      '\n.dotbuild/\n.gluon/\nengine/\nfirefox-*/\nnode_modules/\n'
 
     writeFileSync(gitignore, gitignoreContents)
 


### PR DESCRIPTION
Should fix #24. This ensures that it adds the gluon directory to the gitignore rather than a file named gluon.