### PR TITLE
Improve download behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Improved error handling and logging for the download command
+- `download`: The `engine/` directory will only be deleted if it is empty. Otherwise it will skip. Justification can be found in [#27](https://github.com/pulse-browser/gluon/issues/27)
 
 ## [1.0.0-rc.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Improved error handling and logging for the download command
+
 ## [1.0.0-rc.2]
 
 ### Fixed

--- a/src/cmds.ts
+++ b/src/cmds.ts
@@ -64,8 +64,14 @@ export const commands: Cmd[] = [
     requestController: async () => (await import('./commands/discard')).discard,
   },
   {
-    cmd: 'download [ffVersion]',
+    cmd: 'download',
     description: 'Download Firefox.',
+    options: [
+      {
+        arg: '--force',
+        description: 'Delete the engine directory if it already exists',
+      }
+    ],
     requestController: async () =>
       (await import('./commands/download')).download,
   },

--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -4,12 +4,15 @@
 
 import { bin_name, config } from '..'
 import { log } from '../log'
-
 import {
   downloadInternals
 } from './download/firefox'
 
-export const download = async (): Promise<void> => {
+type Options = {
+  force?: boolean
+}
+
+export const download = async (options: Options): Promise<void> => {
   const version = config.version.version
 
   // If gFFVersion isn't specified, provide legible error
@@ -20,7 +23,7 @@ export const download = async (): Promise<void> => {
     process.exit(1)
   }
 
-  await downloadInternals(version)
+  await downloadInternals({version, force: options.force})
 
   log.success(
     `You should be ready to make changes to ${config.name}.`,

--- a/src/commands/download/addon.ts
+++ b/src/commands/download/addon.ts
@@ -62,7 +62,12 @@ export async function resolveAddonDownloadUrl(
     case 'github': {
       try {
         const githubData = await axios.get(
-          `https://api.github.com/repos/${addon.repo}/releases/tags/${addon.version}`
+          `https://api.github.com/repos/${addon.repo}/releases/tags/${addon.version}`,
+          {
+            headers: {
+              UserAgent: 'gluon-build -> addon downloader'
+            }
+          }
         )
 
         const assets: GithubReleaseAssets = githubData.data.assets

--- a/src/commands/download/firefox.ts
+++ b/src/commands/download/firefox.ts
@@ -120,12 +120,11 @@ export async function downloadInternals(version: string) {
     process.exit(1)
   }
 
-  // If the engine directory is empty, we should delete its contents
+  // If the engine directory is empty, we should delete it.
   const engineIsEmpty = await readdir(ENGINE_DIR).then((files) => files.length === 0)
   if (existsSync(ENGINE_DIR) && engineIsEmpty) {
-    log.info("'engine/' is empty, deleting contents...")
+    log.info("'engine/' is empty, it...")
     rmSync(ENGINE_DIR, { recursive: true })
-
   }
 
   if (!existsSync(ENGINE_DIR)) {

--- a/src/commands/download/firefox.ts
+++ b/src/commands/download/firefox.ts
@@ -1,6 +1,8 @@
 import execa from 'execa'
 import { existsSync, rmSync, writeFileSync } from 'node:fs'
+import { readdir } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
+
 import { bin_name } from '../..'
 import { BASH_PATH, ENGINE_DIR, MELON_TMP_DIR } from '../../constants'
 import { log } from '../../log'
@@ -19,7 +21,6 @@ import {
   unpackAddon,
 } from './addon'
 import { configPath } from '../../utils'
-import { readdir } from 'node:fs/promises'
 
 export function shouldSetupFirefoxSource() {
   return !(
@@ -111,13 +112,18 @@ async function downloadFirefoxSource(version: string) {
   return filename
 }
 
-export async function downloadInternals(version: string) {
+export async function downloadInternals({ version, force }: { version: string, force?: boolean }) {
   // Provide a legible error if there is no version specified
   if (!version) {
     log.error(
       'You have not specified a version of firefox in your config file. This is required to build a firefox fork.'
     )
     process.exit(1)
+  }
+
+  if (force && existsSync(ENGINE_DIR)) {
+    log.info('Removing existing workspace')
+    rmSync(ENGINE_DIR, { recursive: true })
   }
 
   // If the engine directory is empty, we should delete it.

--- a/src/commands/setup-project.ts
+++ b/src/commands/setup-project.ts
@@ -158,7 +158,7 @@ export async function setupProject(): Promise<void> {
     }
 
     gitignoreContents +=
-      '\n.dotbuild/\n.gluon\nengine/\nfirefox-*/\nnode_modules/\n'
+      '\n.dotbuild/\n.gluon/\nengine/\nfirefox-*/\nnode_modules/\n'
 
     writeFileSync(gitignore, gitignoreContents)
 

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,7 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import { existsSync, rmSync } from 'node:fs'
 
 import { bin_name, config } from '..'
 import { log } from '../log'
@@ -9,15 +8,13 @@ import {
   downloadInternals
 } from './download/firefox'
 import { getLatestFF } from '../utils'
-import { ENGINE_DIR } from '../constants'
 
 export const update = async (): Promise<void> => {
   const version = await getLatestFF(config.version.product)
 
-  // Delete the existing engine directory to download the new version
-  if (existsSync(ENGINE_DIR)) rmSync(ENGINE_DIR, { recursive: true })
-
-  await downloadInternals(version)
+  // We are using force here to delete the engine directory if it already
+  // exists to make way for the new version.
+  await downloadInternals({version, force: true})
 
   log.success(
     `Firefox has successfully been updated to ${version}.`,

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,22 +1,26 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import { existsSync, rmSync } from 'node:fs'
 
 import { bin_name, config } from '..'
 import { log } from '../log'
-
 import {
   downloadInternals
 } from './download/firefox'
 import { getLatestFF } from '../utils'
+import { ENGINE_DIR } from '../constants'
 
 export const update = async (): Promise<void> => {
   const version = await getLatestFF(config.version.product)
 
+  // Delete the existing engine directory to download the new version
+  if (existsSync(ENGINE_DIR)) rmSync(ENGINE_DIR, { recursive: true })
+
   await downloadInternals(version)
 
   log.success(
-    `Firefox has sucessfully been updated to ${version}.`,
+    `Firefox has successfully been updated to ${version}.`,
     `You should be ready to make changes to ${config.name}.`,
     '',
     `You should import the patches next, run |${bin_name} import|.`,


### PR DESCRIPTION
There are a few problems with download that this solves:
a) There isn't enough logging, especially with GitHub addons, to be helpful in error reports
b) Download didn't allow you to download extensions without redownloading `engine/` (regression from #25)

@splatboydev because this is changing behavior, can you review this?