### PR TITLE
Change the default repo

### DIFF
--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -28,7 +28,7 @@ export const download = async (options: Options): Promise<void> => {
   log.success(
     `You should be ready to make changes to ${config.name}.`,
     '',
-    'Remember to change the repository in configs/common/mozconfig to your own.'.
+    'Remember to change the repository in configs/common/mozconfig to your own.',
     `You should import the patches next, run |${bin_name} import|.`,
     `To begin building ${config.name}, run |${bin_name} build|.`
   )

--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -28,6 +28,7 @@ export const download = async (options: Options): Promise<void> => {
   log.success(
     `You should be ready to make changes to ${config.name}.`,
     '',
+    'Remember to change the repository in configs/common/mozconfig to your own.'.
     `You should import the patches next, run |${bin_name} import|.`,
     `To begin building ${config.name}, run |${bin_name} build|.`
   )

--- a/template/configs/common/mozconfig
+++ b/template/configs/common/mozconfig
@@ -14,7 +14,8 @@ export MOZ_DISTRIBUTION_ID=${appId}
 # Misc
 export MOZ_STUB_INSTALLER=1
 export MOZ_INCLUDE_SOURCE_INFO=1
-export MOZ_SOURCE_REPO=https://github.com/dothq/browser-desktop
+# Change the below repository to your GitHub repository.
+export MOZ_SOURCE_REPO=https://github.com/example/example
 export MOZ_SOURCE_CHANGESET=${changeset}
 
 # Bootstrap


### PR DESCRIPTION
### Default repo is changed to example/example.
This makes the download command remind the user to change the repository in the mozconfig.